### PR TITLE
Convert datetimes to ISO 8601

### DIFF
--- a/schwab/client/base.py
+++ b/schwab/client/base.py
@@ -83,13 +83,13 @@ class BaseClient(EnumEnforcer):
             raise ValueError(error_str)
 
     def _format_date_as_iso(self, var_name, dt):
-        '''Formats datetime or date objects as yyyy-MM-dd'T'HH:mm:ss.SSSZ'''
+        '''Formats datetime or date objects as ISO 8601'''
         self._assert_type(var_name, dt, [self._DATE, self._DATETIME])
 
         if not isinstance(dt, self._DATETIME):
             dt = datetime.datetime(year=dt.year, month=dt.month, day=dt.day)
 
-        return dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+        return dt.isoformat()
 
     def _format_date_as_day(self, var_name, dt):
         '''Formats datetime or date objects as YYYY-MM-DD'''


### PR DESCRIPTION
The existing code always interprets the datetime object as UTC, regardless of any actual timezone set on the object. This leads to incorrect values when using non-UTC timezones.

The API doc states:
"Valid ISO-8601 formats are :
yyyy-MM-dd'T'HH:mm:ss.SSSZ Example fromEnteredTime is '2024-03-29T00:00:00.000Z'."

It's ambiguous, but I believe this is saying valid ISO 8601 strings are ok, not just those ending in "Z". I've tested the API with a UTC offset (e.g. "2024-08-03T10:51:44.203150-04:00"), and it honors the time with the specified offset.