### PR TITLE
Add price offset to OrderBuilder for trailing stop limit orders

### DIFF
--- a/docs/order-builder.rst
+++ b/docs/order-builder.rst
@@ -526,3 +526,6 @@ these fields at their own risk.
 
 .. automethod:: schwab.orders.generic.OrderBuilder.set_activation_price
 .. automethod:: schwab.orders.generic.OrderBuilder.clear_activation_price
+
+.. automethod:: schwab.orders.generic.OrderBuilder.set_price_offset
+.. automethod:: schwab.orders.generic.OrderBuilder.clear_price_offset

--- a/schwab/orders/generic.py
+++ b/schwab/orders/generic.py
@@ -70,6 +70,7 @@ class OrderBuilder(EnumEnforcer):
         self._stopType = None
         self._priceLinkBasis = None
         self._priceLinkType = None
+        self._priceOffset = None
         self._price = None
         self._orderLegCollection = None
         self._activationPrice = None
@@ -311,6 +312,14 @@ class OrderBuilder(EnumEnforcer):
         Clear the price link basis.
         '''
         self._priceLinkType = None
+        return self
+
+    def set_price_offset(self, price_offset):
+        self._priceOffset = price_offset
+        return self
+
+    def clear_price_offset(self):
+        self._priceOffset = None
         return self
 
     # Price

--- a/tests/orders/generic_test.py
+++ b/tests/orders/generic_test.py
@@ -1130,6 +1130,49 @@ class OrderBuilderExamplesTest(unittest.TestCase):
 
         self.assertFalse(has_diff(expected, builder.build()))
 
+    @no_duplicates
+    def test_sell_trailing_stop_limit_stock(self):
+        builder = (
+            OrderBuilder()
+            .set_complex_order_strategy_type(ComplexOrderStrategyType.NONE)
+            .set_order_type(OrderType.TRAILING_STOP_LIMIT)
+            .set_session(Session.NORMAL)
+            .set_stop_price_link_basis(StopPriceLinkBasis.BID)
+            .set_stop_price_link_type(StopPriceLinkType.VALUE)
+            .set_stop_price_offset(10)
+            .set_price_link_basis(PriceLinkBasis.LAST)
+            .set_price_link_type(PriceLinkType.VALUE)
+            .set_price_offset(12)
+            .set_duration(Duration.DAY)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(EquityInstruction.SELL, 'XYZ', 10))
+
+        expected = {
+            'complexOrderStrategyType': 'NONE',
+            'orderType': 'TRAILING_STOP_LIMIT',
+            'session': 'NORMAL',
+            'stopPriceLinkBasis': 'BID',
+            'stopPriceLinkType': 'VALUE',
+            'stopPriceOffset': 10,
+            'priceLinkBasis': 'LAST',
+            'priceLinkType': 'VALUE',
+            'priceOffset': 12,
+            'duration': 'DAY',
+            'orderStrategyType': 'SINGLE',
+            'orderLegCollection': [
+                {
+                    'instruction': 'SELL',
+                    'quantity': 10,
+                    'instrument': {
+                        'symbol': 'XYZ',
+                        'assetType': 'EQUITY'
+                    }
+                }
+            ]
+        }
+
+        self.assertFalse(has_diff(expected, builder.build()))
+
 
 class TruncateFloatTest(unittest.TestCase):
 


### PR DESCRIPTION
Adds the undocumented field `priceOffset` to the `OrderBuilder` to support trailing stop limit orders.