### PR TITLE
[188] Use loop.run_until_complete

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -61,7 +61,8 @@ of slightly increased application complexity.
 
   if __name__ == '__main__':
       import asyncio
-      asyncio.run_until_complete(main())
+      loop = asyncio.get_event_loop()
+      loop.run_until_complete(main())
 
 +++++++++++++++++++
 Calling Conventions


### PR DESCRIPTION
Change the example code in client.rst to use `loop.run_until_complete` instead of the nonexistent `asyncio.run_until_complete`.