### PR TITLE
Add order types and gtc orders

### DIFF
--- a/schwab/orders/equities.py
+++ b/schwab/orders/equities.py
@@ -1,8 +1,11 @@
 from enum import Enum
 from schwab.orders.common import Duration, EquityInstruction, OrderStrategyType, OrderType, \
                                  Session, StopType, StopPriceLinkType, StopPriceLinkBasis
+from schwab.orders.generic import OrderBuilder
+
 
 gtc_days_default = 120
+
 
 ##########################################################################
 # Buy orders

--- a/schwab/orders/equities.py
+++ b/schwab/orders/equities.py
@@ -1,43 +1,77 @@
 from enum import Enum
+from schwab.orders.common import Duration, EquityInstruction, OrderStrategyType, OrderType, \
+                                 Session, StopType, StopPriceLinkType, StopPriceLinkBasis
 
-from schwab.orders.common import Duration, Session
-
+gtc_days_default = 120
 
 ##########################################################################
 # Buy orders
 
-
-def equity_buy_market(symbol, quantity):
+def equity_buy_market(symbol, quantity, session=Session.NORMAL, duration=Duration.DAY):
     '''
     Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
     buy market order.
     '''
-    from schwab.orders.common import Duration, EquityInstruction
-    from schwab.orders.common import OrderStrategyType, OrderType, Session
-    from schwab.orders.generic import OrderBuilder
-
     return (OrderBuilder()
             .set_order_type(OrderType.MARKET)
-            .set_session(Session.NORMAL)
-            .set_duration(Duration.DAY)
+            .set_session(session)
+            .set_duration(duration)
             .set_order_strategy_type(OrderStrategyType.SINGLE)
             .add_equity_leg(EquityInstruction.BUY, symbol, quantity))
 
 
-def equity_buy_limit(symbol, quantity, price):
+def equity_buy_limit(symbol, quantity, price, session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default):
     '''
     Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
     buy limit order.
     '''
-    from schwab.orders.common import Duration, EquityInstruction
-    from schwab.orders.common import OrderStrategyType, OrderType, Session
-    from schwab.orders.generic import OrderBuilder
 
     return (OrderBuilder()
             .set_order_type(OrderType.LIMIT)
             .set_price(price)
-            .set_session(Session.NORMAL)
-            .set_duration(Duration.DAY)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(EquityInstruction.BUY, symbol, quantity))
+
+def equity_buy_stop(symbol, quantity, price, session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default):
+    '''
+    Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
+    buy limit order.
+    '''
+
+    return (OrderBuilder()
+            .set_order_type(OrderType.STOP)
+            .set_stop_price(price)
+            .set_stop_type(StopType.STANDARD)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(EquityInstruction.BUY, symbol, quantity))
+
+
+def equity_buy_trailing_stop(symbol, quantity, price_offset,
+                             session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default,
+                             stop_price_link_type=StopPriceLinkType.VALUE,
+                             stop_price_link_basis=StopPriceLinkBasis.MARK,
+                             stop_type=StopType.MARK
+                             ):
+    '''
+    Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
+    buy limit order.
+    '''
+
+    return (OrderBuilder()
+            .set_order_type(OrderType.TRAILING_STOP)
+            .set_stop_price_offset(price_offset)
+            .set_price_link_type(stop_price_link_type)
+            .set_stop_price_link_basis(stop_price_link_basis)
+            .set_stop_type(stop_type)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
             .set_order_strategy_type(OrderStrategyType.SINGLE)
             .add_equity_leg(EquityInstruction.BUY, symbol, quantity))
 
@@ -45,112 +79,218 @@ def equity_buy_limit(symbol, quantity, price):
 # Sell orders
 
 
-def equity_sell_market(symbol, quantity):
+def equity_sell_market(symbol, quantity, session=Session.NORMAL, duration=Duration.DAY):
     '''
     Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
     sell market order.
     '''
-    from schwab.orders.common import Duration, EquityInstruction
-    from schwab.orders.common import OrderStrategyType, OrderType, Session
-    from schwab.orders.generic import OrderBuilder
 
     return (OrderBuilder()
             .set_order_type(OrderType.MARKET)
-            .set_session(Session.NORMAL)
-            .set_duration(Duration.DAY)
+            .set_session(session)
+            .set_duration(duration)
             .set_order_strategy_type(OrderStrategyType.SINGLE)
             .add_equity_leg(EquityInstruction.SELL, symbol, quantity))
 
 
-def equity_sell_limit(symbol, quantity, price):
+def equity_sell_limit(symbol, quantity, price, session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default):
     '''
     Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
     sell limit order.
     '''
-    from schwab.orders.common import Duration, EquityInstruction
-    from schwab.orders.common import OrderStrategyType, OrderType, Session
-    from schwab.orders.generic import OrderBuilder
 
     return (OrderBuilder()
             .set_order_type(OrderType.LIMIT)
             .set_price(price)
-            .set_session(Session.NORMAL)
-            .set_duration(Duration.DAY)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
             .set_order_strategy_type(OrderStrategyType.SINGLE)
             .add_equity_leg(EquityInstruction.SELL, symbol, quantity))
+
+def equity_sell_stop(symbol, quantity, price, session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default):
+    '''
+    Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
+    buy limit order.
+    '''
+
+    return (OrderBuilder()
+            .set_order_type(OrderType.STOP)
+            .set_stop_price(price)
+            .set_stop_type(StopType.STANDARD)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(EquityInstruction.SELL, symbol, quantity))
+
+
+def equity_sell_trailing_stop(symbol, quantity, price_offset,
+                             session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default,
+                             stop_price_link_type=StopPriceLinkType.VALUE,
+                             stop_price_link_basis=StopPriceLinkBasis.MARK,
+                             stop_type=StopType.MARK
+                             ):
+    '''
+    Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
+    buy limit order.
+    '''
+
+    return (OrderBuilder()
+            .set_order_type(OrderType.TRAILING_STOP)
+            .set_stop_price_offset(price_offset)
+            .set_price_link_type(stop_price_link_type)
+            .set_stop_price_link_basis(stop_price_link_basis)
+            .set_stop_type(stop_type)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(EquityInstruction.SELL, symbol, quantity))
+
+
 
 ##########################################################################
 # Short sell orders
 
 
-def equity_sell_short_market(symbol, quantity):
+def equity_sell_short_market(symbol, quantity, session=Session.NORMAL, duration=Duration.DAY):
     '''
     Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
     short sell market order.
     '''
-    from schwab.orders.common import Duration, EquityInstruction
-    from schwab.orders.common import OrderStrategyType, OrderType, Session
-    from schwab.orders.generic import OrderBuilder
 
     return (OrderBuilder()
             .set_order_type(OrderType.MARKET)
-            .set_session(Session.NORMAL)
-            .set_duration(Duration.DAY)
+            .set_session(session)
+            .set_duration(duration)
             .set_order_strategy_type(OrderStrategyType.SINGLE)
             .add_equity_leg(EquityInstruction.SELL_SHORT, symbol, quantity))
 
 
-def equity_sell_short_limit(symbol, quantity, price):
+def equity_sell_short_limit(symbol, quantity, price, session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default):
     '''
     Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
     short sell limit order.
     '''
-    from schwab.orders.common import Duration, EquityInstruction
-    from schwab.orders.common import OrderStrategyType, OrderType, Session
-    from schwab.orders.generic import OrderBuilder
 
     return (OrderBuilder()
             .set_order_type(OrderType.LIMIT)
             .set_price(price)
-            .set_session(Session.NORMAL)
-            .set_duration(Duration.DAY)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
             .set_order_strategy_type(OrderStrategyType.SINGLE)
             .add_equity_leg(EquityInstruction.SELL_SHORT, symbol, quantity))
 
+def equity_sell_short_stop(symbol, quantity, price, session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default):
+    '''
+    Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
+    buy limit order.
+    '''
+
+    return (OrderBuilder()
+            .set_order_type(OrderType.STOP)
+            .set_stop_price(price)
+            .set_stop_type(StopType.STANDARD)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(EquityInstruction.SELL_SHORT, symbol, quantity))
+
+
+def equity_sell_short_trailing_stop(symbol, quantity, price_offset,
+                             session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default,
+                             stop_price_link_type=StopPriceLinkType.VALUE,
+                             stop_price_link_basis=StopPriceLinkBasis.MARK,
+                             stop_type=StopType.MARK
+                             ):
+    '''
+    Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
+    buy limit order.
+    '''
+
+    return (OrderBuilder()
+            .set_order_type(OrderType.TRAILING_STOP)
+            .set_stop_price_offset(price_offset)
+            .set_price_link_type(stop_price_link_type)
+            .set_stop_price_link_basis(stop_price_link_basis)
+            .set_stop_type(stop_type)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(EquityInstruction.SELL_SHORT, symbol, quantity))
 ##########################################################################
 # Buy to cover orders
 
 
-def equity_buy_to_cover_market(symbol, quantity):
+def equity_buy_to_cover_market(symbol, quantity, session=Session.NORMAL, duration=Duration.DAY,):
     '''
     Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
     buy-to-cover market order.
     '''
-    from schwab.orders.common import Duration, EquityInstruction
-    from schwab.orders.common import OrderStrategyType, OrderType, Session
-    from schwab.orders.generic import OrderBuilder
 
     return (OrderBuilder()
             .set_order_type(OrderType.MARKET)
-            .set_session(Session.NORMAL)
-            .set_duration(Duration.DAY)
+            .set_session(session)
+            .set_duration(duration)
             .set_order_strategy_type(OrderStrategyType.SINGLE)
             .add_equity_leg(EquityInstruction.BUY_TO_COVER, symbol, quantity))
 
 
-def equity_buy_to_cover_limit(symbol, quantity, price):
+def equity_buy_to_cover_limit(symbol, quantity, price, session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default):
     '''
     Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
     buy-to-cover limit order.
     '''
-    from schwab.orders.common import Duration, EquityInstruction
-    from schwab.orders.common import OrderStrategyType, OrderType, Session
-    from schwab.orders.generic import OrderBuilder
 
     return (OrderBuilder()
             .set_order_type(OrderType.LIMIT)
             .set_price(price)
-            .set_session(Session.NORMAL)
-            .set_duration(Duration.DAY)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(EquityInstruction.BUY_TO_COVER, symbol, quantity))
+
+def equity_buy_to_cover_stop(symbol, quantity, price, session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default):
+    '''
+    Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
+    buy limit order.
+    '''
+
+    return (OrderBuilder()
+            .set_order_type(OrderType.STOP)
+            .set_stop_price(price)
+            .set_stop_type(StopType.STANDARD)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
+            .set_order_strategy_type(OrderStrategyType.SINGLE)
+            .add_equity_leg(EquityInstruction.BUY_TO_COVER, symbol, quantity))
+
+
+def equity_buy_to_cover_trailing_stop(symbol, quantity, price_offset,
+                             session=Session.NORMAL, duration=Duration.DAY, date_input=gtc_days_default,
+                             stop_price_link_type=StopPriceLinkType.VALUE,
+                             stop_price_link_basis=StopPriceLinkBasis.MARK,
+                             stop_type=StopType.MARK
+                             ):
+    '''
+    Returns a pre-filled :class:`~schwab.orders.generic.OrderBuilder` for an equity
+    buy limit order.
+    '''
+
+    return (OrderBuilder()
+            .set_order_type(OrderType.TRAILING_STOP)
+            .set_stop_price_offset(price_offset)
+            .set_price_link_type(stop_price_link_type)
+            .set_stop_price_link_basis(stop_price_link_basis)
+            .set_stop_type(stop_type)
+            .set_session(session)
+            .set_duration(duration)
+            .set_cancel_date(date_input, duration)
             .set_order_strategy_type(OrderStrategyType.SINGLE)
             .add_equity_leg(EquityInstruction.BUY_TO_COVER, symbol, quantity))

--- a/schwab/orders/generic.py
+++ b/schwab/orders/generic.py
@@ -4,7 +4,9 @@ from enum import Enum
 
 from schwab.orders import common
 from schwab.utils import EnumEnforcer
+from schwab.orders.common import Duration
 
+from datetime import datetime, timedelta
 import httpx
 
 

--- a/schwab/orders/generic.py
+++ b/schwab/orders/generic.py
@@ -111,6 +111,45 @@ class OrderBuilder(EnumEnforcer):
         self._duration = None
         return self
 
+    def _get_weekday(self, days_from_now):
+        """
+        Get the first weekday (Monday to Friday) that is `days_from_now` days
+        from today. If the resulting day falls on a weekend, adjust to the
+        following Monday. The date always uses the time "20:00:00+0000".
+        """
+        target_date = datetime.utcnow() + timedelta(days=days_from_now)
+
+        # If the day is Saturday (5) or Sunday (6), adjust to Monday
+        if target_date.weekday() == 5:  # Saturday
+            target_date += timedelta(days=2)
+        elif target_date.weekday() == 6:  # Sunday
+            target_date += timedelta(days=1)
+
+        # Set the time to 20:00:00 UTC
+        target_date = target_date.replace(hour=20, minute=0, second=0, microsecond=0)
+        return target_date
+
+    def set_cancel_date(self, date_input, duration):
+        """
+        Set the date. The date can be passed as either a `datetime` object
+        or an `int` (representing days from today). The date is formatted
+        as an ISO 8601 string with the fixed time "20:00:00+0000".
+        """
+        if not (duration == Duration.GOOD_TILL_CANCEL):
+            return self
+
+        if isinstance(date_input, datetime):
+            date = date_input
+        elif isinstance(date_input, int):
+            date = self._get_weekday(days_from_now=date_input)
+        else:
+            raise ValueError("date_input must be a datetime object or an integer (days from today).")
+
+        # Set the time to 20:00:00 UTC
+        date = date.replace(hour=20, minute=0, second=0, microsecond=0)
+        self._cancelTime = date.strftime("%Y-%m-%dT%H:%M:%S+0000")
+        return self
+
     # OrderType
     def set_order_type(self, order_type):
         '''


### PR DESCRIPTION
* Added additional order types that allow for stop and trailing stop orders both short and long.
* Added ability to specify a Good Til Cancel date via specifying number of days until exit on each order type.

Use at your own risk.