### PR TITLE
Add support for async token_read_func

### DIFF
--- a/schwab/auth.py
+++ b/schwab/auth.py
@@ -494,6 +494,41 @@ def client_from_manual_flow(api_key, app_secret, callback_url, token_path,
             api_key, app_secret, auth_context, received_url, token_write_func, 
             asyncio, enforce_enums)
 
+################################################################################
+# client_from_access_functions_async
+
+async def client_from_access_functions_async(api_key, app_secret, token_read_func,
+                                             token_write_func, asyncio=False,
+                                             enforce_enums=True):
+    '''
+    Async wrapper around client_from_access_functions to be able to use an async token_read_func.
+
+    :param api_key: Your Schwab application's app key.
+    :param app_secret: Application secret. Provided upon :ref:`app approval
+                       <approved_pending>`.
+    :param token_read_func: Async function that takes no arguments and returns a token
+                            object.
+    :param token_write_func: Function that writes the token on update. Will be
+                             called whenever the token is updated, such as when
+                             it is refreshed. See the above-mentioned example
+                             for what parameters this method takes.
+    :param asyncio: If set to ``True``, this will enable async support allowing
+                    the client to be used in an async environment. Defaults to
+                    ``False``
+    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL
+                          the client methods. Only do it if you know you really
+                          need it. For most users, it is advised to use enums
+                          to avoid errors.
+    '''
+    token = await token_read_func()
+
+    def token_read_func():
+        return token
+
+    return client_from_access_functions(api_key, app_secret, token_read_func, token_write_func, asyncio, enforce_enums)
+
+
+
 
 ################################################################################
 # client_from_access_functions

--- a/schwab/auth.py
+++ b/schwab/auth.py
@@ -19,6 +19,7 @@ import webbrowser
 from schwab.client import AsyncClient, Client
 from schwab.debug import register_redactions
 
+
 TOKEN_ENDPOINT = 'https://api.schwabapi.com/v1/oauth/token'
 
 
@@ -32,8 +33,6 @@ def __make_update_token_func(token_path):
 
         with open(token_path, 'w') as f:
             json.dump(t, f)
-
-
     return update_token
 
 
@@ -43,8 +42,6 @@ def __token_loader(token_path):
 
         with open(token_path, 'rb') as f:
             return json.load(f)
-
-
     return load_token
 
 
@@ -53,8 +50,6 @@ class TokenMetadata:
     Provides the functionality required to maintain and update our view of the
     token's metadata.
     '''
-
-
     def __init__(self, token, creation_timestamp, unwrapped_token_write_func):
         '''
         :param token: The token to wrap in metadata
@@ -78,7 +73,6 @@ class TokenMetadata:
         # is called.
         self.token = token
 
-
     @classmethod
     def from_loaded_token(cls, token, unwrapped_token_write_func):
         '''
@@ -88,28 +82,24 @@ class TokenMetadata:
         '''
         if 'creation_timestamp' not in token:
             raise ValueError(
-                'WARNING: The token format has changed since this token ' +
-                'was created. Please delete it and create a new one.')
+                    'WARNING: The token format has changed since this token '+
+                    'was created. Please delete it and create a new one.')
 
         return TokenMetadata(
-            token['token'],
-            token['creation_timestamp'],
-            unwrapped_token_write_func)
-
+                token['token'],
+                token['creation_timestamp'],
+                unwrapped_token_write_func)
 
     def token_age(self):
         '''Returns the number of second elapsed since this token was initially 
         created.'''
         return int(time.time()) - self.creation_timestamp
 
-
     def wrapped_token_write_func(self):
         '''
         Returns a version of the unwrapped write function which wraps the token 
         in metadata and updates our view on the most recent token.
         '''
-
-
         def wrapped_token_write_func(token, *args, **kwargs):
             # If the write function is going to raise an exception, let it do so 
             # here before we update our reference to the current token.
@@ -120,9 +110,7 @@ class TokenMetadata:
 
             return ret
 
-
         return wrapped_token_write_func
-
 
     def wrap_token_in_metadata(self, token):
         return {
@@ -145,17 +133,14 @@ def __run_client_from_login_flow_server(
 
     app = flask.Flask(__name__)
 
-
     @app.route(callback_path)
     def handle_token():
         q.put(flask.request.url)
         return 'schwab-py callback received! You may now close this window/tab.'
 
-
     @app.route('/schwab-py-internal/status')
     def status():
         return 'running'
-
 
     if callback_port == 443:
         return
@@ -175,15 +160,12 @@ def __run_client_from_login_flow_server(
 class RedirectTimeoutError(Exception):
     pass
 
-
 class RedirectServerExitedError(Exception):
     pass
-
 
 # Capture the real time.time so that we can use it in server initialization
 # while simultaneously mocking it in testing
 __TIME_TIME = time.time
-
 
 def client_from_login_flow(api_key, app_secret, callback_url, token_path,
                            asyncio=False, enforce_enums=False,
@@ -267,11 +249,11 @@ def client_from_login_flow(api_key, app_secret, callback_url, token_path,
     if parsed.hostname != '127.0.0.1':
         # TODO: document this error
         raise ValueError(
-            ('Disallowed hostname {}. client_from_login_flow only allows ' +
-             'callback URLs with hostname 127.0.0.1. See here for ' +
-             'more information: https://schwab-py.readthedocs.io/en/' +
-             'latest/auth.html#callback-url-advisory').format(
-                parsed.hostname))
+                ('Disallowed hostname {}. client_from_login_flow only allows '+
+                 'callback URLs with hostname 127.0.0.1. See here for ' +
+                 'more information: https://schwab-py.readthedocs.io/en/' +
+                 'latest/auth.html#callback-url-advisory').format(
+                     parsed.hostname))
 
     callback_port = parsed.port if parsed.port else 443
     callback_path = parsed.path if parsed.path else '/'
@@ -279,9 +261,8 @@ def client_from_login_flow(api_key, app_secret, callback_url, token_path,
     output_queue = multiprocess.Queue()
 
     server = multiprocess.Process(
-        target=__run_client_from_login_flow_server,
-        args=(output_queue, callback_port, callback_path))
-
+            target=__run_client_from_login_flow_server,
+            args=(output_queue, callback_port, callback_path))
 
     # Context manager to kill the server upon completion
     @contextlib.contextmanager
@@ -296,7 +277,6 @@ def client_from_login_flow(api_key, app_secret, callback_url, token_path,
             except psutil.NoSuchProcess:
                 pass
 
-
     with callback_server():
         # Wait until the server successfully starts
         while True:
@@ -304,8 +284,8 @@ def client_from_login_flow(api_key, app_secret, callback_url, token_path,
             if server.exitcode is not None:
                 # TODO: document this error
                 raise RedirectServerExitedError(
-                    'Redirect server exited. Are you attempting to use a ' +
-                    'callback URL without a port number specified?')
+                        'Redirect server exited. Are you attempting to use a ' +
+                        'callback URL without a port number specified?')
 
             import traceback
 
@@ -313,12 +293,12 @@ def client_from_login_flow(api_key, app_secret, callback_url, token_path,
             try:
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
-                        'ignore',
-                        category=urllib3.exceptions.InsecureRequestWarning)
+                            'ignore',
+                            category=urllib3.exceptions.InsecureRequestWarning)
 
                     resp = httpx.get(
-                        'https://127.0.0.1:{}/schwab-py-internal/status'.format(
-                            callback_port), verify=False)
+                            'https://127.0.0.1:{}/schwab-py-internal/status'.format(
+                                callback_port), verify=False)
                 break
             except httpx.ConnectError as e:
                 pass
@@ -346,7 +326,7 @@ def client_from_login_flow(api_key, app_secret, callback_url, token_path,
         print('callback URL, ignoring URL parameters. As a reminder, your callback URL')
         print('is:')
         print()
-        print('>>', callback_url)
+        print('>>',callback_url)
         print()
         print('See here to learn more about self-signed SSL certificates:')
         print('https://schwab-py.readthedocs.io/en/latest/auth.html#ssl-errors')
@@ -382,24 +362,24 @@ def client_from_login_flow(api_key, app_secret, callback_url, token_path,
             # Attempt to fetch from the queue
             try:
                 received_url = output_queue.get(
-                    timeout=min(timeout_time - now, 0.1))
+                        timeout=min(timeout_time - now, 0.1))
                 break
             except queue.Empty:
                 pass
 
         if not received_url:
             raise RedirectTimeoutError(
-                'Timed out waiting for a post-authorization callback. You ' +
-                'can set a longer timeout by passing a value of ' +
-                'callback_timeout to client_from_login_flow.')
+                    'Timed out waiting for a post-authorization callback. You '+
+                    'can set a longer timeout by passing a value of ' +
+                    'callback_timeout to client_from_login_flow.')
 
         token_write_func = (
             __make_update_token_func(token_path) if token_write_func is None
             else token_write_func)
 
         return client_from_received_url(
-            api_key, app_secret, auth_context, received_url,
-            token_write_func, asyncio, enforce_enums)
+                api_key, app_secret, auth_context, received_url,
+                token_write_func, asyncio, enforce_enums)
 
 
 ################################################################################
@@ -469,7 +449,7 @@ def client_from_manual_flow(api_key, app_secret, callback_url, token_path,
                           to avoid errors.
     '''
     get_logger().info('Creating new token with callback URL \'%s\' ' +
-                      'and token path \'%s\'', callback_url, token_path)
+                       'and token path \'%s\'', callback_url, token_path)
 
     auth_context = get_auth_context(api_key, callback_url)
 
@@ -511,9 +491,8 @@ def client_from_manual_flow(api_key, app_secret, callback_url, token_path,
         else token_write_func)
 
     return client_from_received_url(
-        api_key, app_secret, auth_context, received_url, token_write_func,
-        asyncio, enforce_enums)
-
+            api_key, app_secret, auth_context, received_url, token_write_func,
+            asyncio, enforce_enums)
 
 ################################################################################
 # client_from_access_functions_async
@@ -543,12 +522,12 @@ async def client_from_access_functions_async(api_key, app_secret, token_read_fun
     '''
     token = await token_read_func()
 
-
     def token_read_func():
         return token
 
-
     return client_from_access_functions(api_key, app_secret, token_read_func, token_write_func, asyncio, enforce_enums)
+
+
 
 
 ################################################################################
@@ -607,8 +586,6 @@ def client_from_access_functions(api_key, app_secret, token_read_func,
     if asyncio:
         async def oauth_client_update_token(t, *args, **kwargs):
             wrapped_token_write_func(t, *args, **kwargs)  # pragma: no cover
-
-
         session_class = AsyncOAuth2Client
         client_class = AsyncClient
     else:
@@ -633,8 +610,7 @@ def client_from_access_functions(api_key, app_secret, token_read_func,
 
 
 AuthContext = collections.namedtuple(
-    'AuthContext', ['callback_url', 'authorization_url', 'state'])
-
+        'AuthContext', ['callback_url', 'authorization_url', 'state'])
 
 def get_auth_context(api_key, callback_url, state=None):
     oauth = OAuth2Client(api_key, redirect_uri=callback_url)
@@ -675,8 +651,6 @@ def client_from_received_url(
     if asyncio:
         async def oauth_client_update_token(t, *args, **kwargs):
             token_write_func(t, *args, **kwargs)  # pragma: no cover
-
-
         session_class = AsyncOAuth2Client
         client_class = AsyncClient
     else:
@@ -725,7 +699,7 @@ def __running_in_notebook():
 
 
 def easy_client(api_key, app_secret, callback_url, token_path, asyncio=False,
-                enforce_enums=True, max_token_age=60 * 60 * 24 * 6.5,
+                enforce_enums=True, max_token_age=60*60*24*6.5,
                 callback_timeout=300.0, interactive=True,
                 requested_browser=None):
     '''

--- a/tests/auth_async_test.py
+++ b/tests/auth_async_test.py
@@ -1,0 +1,161 @@
+import unittest
+from unittest.mock import ANY as _
+from unittest.mock import patch, AsyncMock
+
+from schwab import auth
+from .utils import (
+    MockAsyncOAuthClient,
+    MockOAuthClient,
+    no_duplicates
+)
+
+API_KEY = 'APIKEY'
+APP_SECRET = '0x5EC07'
+TOKEN_CREATION_TIMESTAMP = 1613745000
+MOCK_NOW = 1613745082
+CALLBACK_URL = 'https://redirect.url.com'
+
+
+class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
+
+
+    def setUp(self):
+        self.raw_token = {'token': 'yes'}
+        self.token = {
+                'token': self.raw_token,
+                'creation_timestamp': TOKEN_CREATION_TIMESTAMP
+        }
+
+
+    @no_duplicates
+    @patch('schwab.auth.Client')
+    @patch('schwab.auth.OAuth2Client', new_callable=MockOAuthClient)
+    @patch('schwab.auth.AsyncOAuth2Client', new_callable=MockAsyncOAuthClient)
+    async def test_success_with_write_func_async(
+            self, async_session, sync_session, client):
+        token_read_func = AsyncMock()
+        token_read_func.return_value = self.token
+
+        token_writes = []
+
+        def token_write_func(token):
+            token_writes.append(token)
+
+        client.return_value = 'returned client'
+        self.assertEqual('returned client',
+                         await auth.client_from_access_functions_async(
+                             API_KEY,
+                             APP_SECRET,
+                             token_read_func,
+                             token_write_func))
+
+        sync_session.assert_called_once_with(
+            API_KEY,
+            client_secret=APP_SECRET,
+            token=self.raw_token,
+            token_endpoint=_,
+            update_token=_,
+            leeway=_)
+        token_read_func.assert_called_once()
+
+        # Verify that the write function is called when the updater is called
+        session_call = sync_session.mock_calls[0]
+        update_token = session_call[2]['update_token']
+
+        update_token(self.raw_token)
+        self.assertEqual([{
+            'creation_timestamp': TOKEN_CREATION_TIMESTAMP,
+            'token': self.raw_token
+        }], token_writes)
+
+    @no_duplicates
+    @patch('schwab.auth.Client')
+    @patch('schwab.auth.OAuth2Client', new_callable=MockOAuthClient)
+    @patch('schwab.auth.AsyncOAuth2Client', new_callable=MockAsyncOAuthClient)
+    async def test_success_with_async_write_func_metadata_aware_token(
+            self, async_session, sync_session, client):
+        token_read_func = AsyncMock()
+        token_read_func.return_value = self.token
+
+        token_writes = []
+
+        def token_write_func(token):
+            token_writes.append(token)
+
+        client.return_value = 'returned client'
+        self.assertEqual('returned client',
+                         await auth.client_from_access_functions_async(
+                             API_KEY,
+                             APP_SECRET,
+                             token_read_func,
+                             token_write_func))
+
+        sync_session.assert_called_once_with(
+            API_KEY,
+            client_secret=APP_SECRET,
+            token=self.raw_token,
+            token_endpoint=_,
+            update_token=_,
+            leeway=_)
+        token_read_func.assert_called_once()
+
+        # Verify that the write function is called when the updater is called
+        session_call = sync_session.mock_calls[0]
+        update_token = session_call[2]['update_token']
+
+        update_token(self.raw_token)
+        self.assertEqual([{
+            'creation_timestamp': TOKEN_CREATION_TIMESTAMP,
+            'token': self.raw_token
+        }], token_writes)
+
+    @no_duplicates
+    @patch('schwab.auth.Client')
+    @patch('schwab.auth.OAuth2Client', new_callable=MockOAuthClient)
+    @patch('schwab.auth.AsyncOAuth2Client', new_callable=MockAsyncOAuthClient)
+    async def test_success_with_enforce_enums_disabled_async(
+            self, async_session, sync_session, client):
+        token_read_func = AsyncMock()
+        token_read_func.return_value = self.token
+
+        token_writes = []
+
+        def token_write_func(token):
+            token_writes.append(token)
+
+        client.return_value = 'returned client'
+        self.assertEqual('returned client',
+                         await auth.client_from_access_functions_async(
+                             API_KEY,
+                             APP_SECRET,
+                             token_read_func,
+                             token_write_func, enforce_enums=False))
+
+        client.assert_called_once_with(
+                API_KEY, _, token_metadata=_, enforce_enums=False)
+
+    @no_duplicates
+    @patch('schwab.auth.Client')
+    @patch('schwab.auth.OAuth2Client', new_callable=MockOAuthClient)
+    @patch('schwab.auth.AsyncOAuth2Client', new_callable=MockAsyncOAuthClient)
+    async def test_success_with_enforce_enums_enabled_async(
+            self, async_session, sync_session, client):
+        token_read_func = AsyncMock()
+        token_read_func.return_value = self.token
+
+        token_writes = []
+
+        def token_write_func(token):
+            token_writes.append(token)
+
+        client.return_value = 'returned client'
+        self.assertEqual('returned client',
+                         await auth.client_from_access_functions_async(
+                             API_KEY,
+                             APP_SECRET,
+                             token_read_func,
+                             token_write_func))
+
+        client.assert_called_once_with(
+                API_KEY, _, token_metadata=_, enforce_enums=True)
+

--- a/tests/auth_async_test.py
+++ b/tests/auth_async_test.py
@@ -18,12 +18,11 @@ CALLBACK_URL = 'https://redirect.url.com'
 
 class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
 
-
     def setUp(self):
         self.raw_token = {'token': 'yes'}
         self.token = {
-                'token': self.raw_token,
-                'creation_timestamp': TOKEN_CREATION_TIMESTAMP
+            'token': self.raw_token,
+            'creation_timestamp': TOKEN_CREATION_TIMESTAMP
         }
 
 
@@ -38,8 +37,10 @@ class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
 
         token_writes = []
 
+
         def token_write_func(token):
             token_writes.append(token)
+
 
         client.return_value = 'returned client'
         self.assertEqual('returned client',
@@ -67,6 +68,7 @@ class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
             'creation_timestamp': TOKEN_CREATION_TIMESTAMP,
             'token': self.raw_token
         }], token_writes)
+
 
     @no_duplicates
     @patch('schwab.auth.Client')
@@ -79,8 +81,10 @@ class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
 
         token_writes = []
 
+
         def token_write_func(token):
             token_writes.append(token)
+
 
         client.return_value = 'returned client'
         self.assertEqual('returned client',
@@ -109,6 +113,7 @@ class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
             'token': self.raw_token
         }], token_writes)
 
+
     @no_duplicates
     @patch('schwab.auth.Client')
     @patch('schwab.auth.OAuth2Client', new_callable=MockOAuthClient)
@@ -120,8 +125,10 @@ class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
 
         token_writes = []
 
+
         def token_write_func(token):
             token_writes.append(token)
+
 
         client.return_value = 'returned client'
         self.assertEqual('returned client',
@@ -132,7 +139,8 @@ class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
                              token_write_func, enforce_enums=False))
 
         client.assert_called_once_with(
-                API_KEY, _, token_metadata=_, enforce_enums=False)
+            API_KEY, _, token_metadata=_, enforce_enums=False)
+
 
     @no_duplicates
     @patch('schwab.auth.Client')
@@ -145,8 +153,10 @@ class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
 
         token_writes = []
 
+
         def token_write_func(token):
             token_writes.append(token)
+
 
         client.return_value = 'returned client'
         self.assertEqual('returned client',
@@ -157,5 +167,4 @@ class ClientFromAccessFunctionsTest(unittest.IsolatedAsyncioTestCase):
                              token_write_func))
 
         client.assert_called_once_with(
-                API_KEY, _, token_metadata=_, enforce_enums=True)
-
+            API_KEY, _, token_metadata=_, enforce_enums=True)


### PR DESCRIPTION
Adds support for an async token_read_func, which is a good use case for using async (blocking I/O operation).  If someone is using `client_from_access_functions`, it is likely that they're using blocking I/O operations to retrieve and store tokens (say from a shared database). There already exists support for using an async token_write_func (provided by `httpx_client.AsyncOAuth2Client`), however the scenario where read is sync and write is async is likely rare or non-existent compared to requiring both to be equally a/synchronous.