### PR TITLE
feat: add base URL support for endpoints

### DIFF
--- a/schwab/__init__.py
+++ b/schwab/__init__.py
@@ -1,3 +1,6 @@
+# Default base URL for Schwab API
+DEFAULT_BASE_URL = 'https://api.schwabapi.com'
+
 from . import auth
 from . import client
 #from . import contrib

--- a/schwab/client/asynchronous.py
+++ b/schwab/client/asynchronous.py
@@ -14,7 +14,7 @@ class AsyncClient(BaseClient):
         await self.session.aclose()
 
     async def _get_request(self, path, params):
-        dest = 'https://api.schwabapi.com' + path
+        dest = self.base_url + path
 
         req_num = self._req_num()
         self.logger.debug('Req %s: GET to %s, params=%s',
@@ -26,7 +26,7 @@ class AsyncClient(BaseClient):
         return resp
 
     async def _post_request(self, path, data):
-        dest = 'https://api.schwabapi.com' + path
+        dest = self.base_url + path
 
         req_num = self._req_num()
         self.logger.debug('Req %s: POST to %s, json=%s',
@@ -38,7 +38,7 @@ class AsyncClient(BaseClient):
         return resp
 
     async def _put_request(self, path, data):
-        dest = 'https://api.schwabapi.com' + path
+        dest = self.base_url + path
 
         req_num = self._req_num()
         self.logger.debug('Req %s: PUT to %s, json=%s',
@@ -50,7 +50,7 @@ class AsyncClient(BaseClient):
         return resp
 
     async def _delete_request(self, path):
-        dest = 'https://api.schwabapi.com' + path
+        dest = self.base_url + path
 
         req_num = self._req_num()
         self.logger.debug('Req %s: DELETE to %s', req_num, dest)

--- a/schwab/client/base.py
+++ b/schwab/client/base.py
@@ -14,6 +14,7 @@ import time
 import warnings
 
 from schwab.orders.generic import OrderBuilder
+from schwab import DEFAULT_BASE_URL
 
 from ..utils import EnumEnforcer
 
@@ -34,13 +35,14 @@ class BaseClient(EnumEnforcer):
     found in the response object's ``json()`` method.'''
 
     def __init__(self, api_key, session, *, enforce_enums=True,
-                 token_metadata=None):
+                 token_metadata=None, base_url=DEFAULT_BASE_URL):
         '''Create a new client with the given API key and session. Set
         `enforce_enums=False` to disable strict input type checking.'''
         super().__init__(enforce_enums)
 
         self.api_key = api_key
         self.session = session
+        self.base_url = base_url
 
         # Logging-related fields
         self.logger = get_logger()

--- a/schwab/client/synchronous.py
+++ b/schwab/client/synchronous.py
@@ -10,7 +10,7 @@ import json
 
 class Client(BaseClient):
     def _get_request(self, path, params):
-        dest = 'https://api.schwabapi.com' + path
+        dest = self.base_url + path
 
         req_num = self._req_num()
         self.logger.debug('Req %s: GET to %s, params=%s',
@@ -22,7 +22,7 @@ class Client(BaseClient):
         return resp
 
     def _post_request(self, path, data):
-        dest = 'https://api.schwabapi.com' + path
+        dest = self.base_url + path
 
         req_num = self._req_num()
         self.logger.debug('Req %s: POST to %s, json=%s',
@@ -34,7 +34,7 @@ class Client(BaseClient):
         return resp
 
     def _put_request(self, path, data):
-        dest = 'https://api.schwabapi.com' + path
+        dest = self.base_url + path
 
         req_num = self._req_num()
         self.logger.debug('Req %s: PUT to %s, json=%s',
@@ -46,7 +46,7 @@ class Client(BaseClient):
         return resp
 
     def _delete_request(self, path):
-        dest = 'https://api.schwabapi.com' + path
+        dest = self.base_url + path
 
         req_num = self._req_num()
         self.logger.debug('Req %s: DELETE to %s'.format(req_num, dest))

--- a/schwab/utils.py
+++ b/schwab/utils.py
@@ -136,7 +136,7 @@ class Utils(EnumEnforcer):
             return None
 
         m = re.match(
-                r'https://api.schwabapi.com/trader/v1/accounts/(\w+)/orders/(\d+)',
+                r'https://[^/]+/trader/v1/accounts/(\w+)/orders/(\d+)',
                 location)
 
         if m is None:

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -329,7 +329,7 @@ class ClientFromTokenFileTest(unittest.TestCase):
                          auth.client_from_token_file(
                              self.token_path, API_KEY, APP_SECRET))
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
-                                       enforce_enums=_)
+                                       enforce_enums=_, base_url=_)
         sync_session.assert_called_once_with(
             API_KEY,
             client_secret=APP_SECRET,
@@ -374,7 +374,7 @@ class ClientFromTokenFileTest(unittest.TestCase):
                              self.token_path, API_KEY, APP_SECRET,
                              enforce_enums=False))
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
-                                       enforce_enums=False)
+                                       enforce_enums=False, base_url=_)
 
     @no_duplicates
     @patch('schwab.auth.Client')
@@ -389,7 +389,7 @@ class ClientFromTokenFileTest(unittest.TestCase):
                          auth.client_from_token_file(
                              self.token_path, API_KEY, APP_SECRET))
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
-                                       enforce_enums=True)
+                                       enforce_enums=True, base_url=_)
 
 
 class ClientFromAccessFunctionsTest(unittest.TestCase):
@@ -508,7 +508,7 @@ class ClientFromAccessFunctionsTest(unittest.TestCase):
                              token_write_func, enforce_enums=False))
 
         client.assert_called_once_with(
-                API_KEY, _, token_metadata=_, enforce_enums=False)
+                API_KEY, _, token_metadata=_, enforce_enums=False, base_url=_)
 
     @no_duplicates
     @patch('schwab.auth.Client')
@@ -533,7 +533,7 @@ class ClientFromAccessFunctionsTest(unittest.TestCase):
                              token_write_func))
 
         client.assert_called_once_with(
-                API_KEY, _, token_metadata=_, enforce_enums=True)
+                API_KEY, _, token_metadata=_, enforce_enums=True, base_url=_)
 
 
 # Note the client_from_received_url is called internally by the other client 
@@ -755,7 +755,7 @@ class ClientFromManualFlow(unittest.TestCase):
                              enforce_enums=False))
 
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
-                                       enforce_enums=False)
+                                       enforce_enums=False, base_url=_)
 
     @no_duplicates
     @patch('schwab.auth.Client')
@@ -779,7 +779,7 @@ class ClientFromManualFlow(unittest.TestCase):
                              API_KEY, APP_SECRET, CALLBACK_URL, self.token_path))
 
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
-                                       enforce_enums=True)
+                                       enforce_enums=True, base_url=_)
 
 
 class TokenMetadataTest(unittest.TestCase):
@@ -943,7 +943,7 @@ class EasyClientTest(unittest.TestCase):
                 API_KEY, APP_SECRET, CALLBACK_URL, self.token_path,
                 asyncio='asyncio', enforce_enums='enforce_enums',
                 callback_timeout='callback_timeout', interactive='interactive',
-                requested_browser='requested_browser')
+                requested_browser='requested_browser', base_url=_)
 
 
     @no_duplicates
@@ -982,7 +982,7 @@ class EasyClientTest(unittest.TestCase):
 
         client_from_token_file.assert_called_once_with(
                 self.token_path, API_KEY, APP_SECRET,
-                asyncio='asyncio', enforce_enums='enforce_enums')
+                asyncio='asyncio', enforce_enums='enforce_enums', base_url=_)
 
 
     @no_duplicates

--- a/tests/test_base_url.py
+++ b/tests/test_base_url.py
@@ -1,0 +1,208 @@
+"""Tests for custom base_url functionality"""
+
+from schwab import auth, DEFAULT_BASE_URL
+from schwab.utils import Utils
+from unittest.mock import patch, MagicMock, ANY as _
+import unittest
+import json
+import tempfile
+import os
+
+
+class CustomBaseUrlTest(unittest.TestCase):
+    """Test that custom base URLs work correctly throughout the system"""
+
+    def setUp(self):
+        self.custom_base_url = 'https://proxy.example.com'
+        self.api_key = 'TEST_API_KEY'
+        self.app_secret = 'TEST_APP_SECRET'
+        self.callback_url = 'https://localhost:8080/callback'
+
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.token_path = os.path.join(self.tmp_dir.name, 'token.json')
+        self.token = {
+            'token': {'access_token': 'test_token'},
+            'creation_timestamp': 1234567890
+        }
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def write_token(self):
+        with open(self.token_path, 'w') as f:
+            json.dump(self.token, f)
+
+    @patch('schwab.auth.Client')
+    @patch('schwab.auth.OAuth2Client')
+    def test_client_from_token_file_with_custom_base_url(self, mock_oauth, mock_client):
+        """Test that client_from_token_file passes base_url correctly"""
+        self.write_token()
+
+        # Call with custom base URL
+        auth.client_from_token_file(
+            self.token_path, self.api_key, self.app_secret,
+            base_url=self.custom_base_url
+        )
+
+        # Verify Client was called with custom base_url
+        mock_client.assert_called_once_with(
+            self.api_key, _, token_metadata=_, enforce_enums=True,
+            base_url=self.custom_base_url
+        )
+
+        # Verify OAuth2Client was called with custom token endpoint
+        mock_oauth.assert_called_once()
+        call_args = mock_oauth.call_args[1]
+        self.assertEqual(
+            call_args['token_endpoint'],
+            self.custom_base_url + '/v1/oauth/token'
+        )
+
+    @patch('schwab.auth.Client')
+    @patch('schwab.auth.OAuth2Client')
+    def test_easy_client_with_custom_base_url(self, mock_oauth, mock_client):
+        """Test that easy_client passes base_url through correctly"""
+        self.write_token()
+
+        mock_client_instance = MagicMock()
+        mock_client.return_value = mock_client_instance
+        mock_client_instance.token_age.return_value = 1
+
+        # Call with custom base URL
+        auth.easy_client(
+            self.api_key, self.app_secret, self.callback_url, self.token_path,
+            base_url=self.custom_base_url
+        )
+
+        # Verify the client was created with custom base_url
+        mock_client.assert_called_once_with(
+            self.api_key, _, token_metadata=_, enforce_enums=True,
+            base_url=self.custom_base_url
+        )
+
+    @patch('schwab.auth.OAuth2Client')
+    def test_get_auth_context_with_custom_base_url(self, mock_oauth):
+        """Test that get_auth_context uses custom base_url for auth endpoint"""
+        mock_oauth_instance = MagicMock()
+        mock_oauth.return_value = mock_oauth_instance
+        mock_oauth_instance.create_authorization_url.return_value = (
+            'https://custom.auth.url', 'state123'
+        )
+
+        # Call with custom base URL
+        auth.get_auth_context(
+            self.api_key, self.callback_url,
+            base_url=self.custom_base_url
+        )
+
+        # Verify create_authorization_url was called with custom auth endpoint
+        mock_oauth_instance.create_authorization_url.assert_called_once_with(
+            self.custom_base_url + '/v1/oauth/authorize',
+            state=None
+        )
+
+    def test_client_http_methods_use_base_url(self):
+        """Test that client HTTP methods use the base_url"""
+        from schwab.client.synchronous import Client
+
+        # Create a mock session
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_session.get.return_value = mock_response
+        mock_session.post.return_value = mock_response
+        mock_session.put.return_value = mock_response
+        mock_session.delete.return_value = mock_response
+
+        # Create client with custom base URL
+        client = Client(
+            api_key=self.api_key,
+            session=mock_session,
+            base_url=self.custom_base_url
+        )
+
+        # Test GET request
+        client._get_request('/test/path', {})
+        mock_session.get.assert_called_with(
+            self.custom_base_url + '/test/path',
+            params={}
+        )
+
+        # Test POST request
+        client._post_request('/test/path', {'data': 'test'})
+        mock_session.post.assert_called_with(
+            self.custom_base_url + '/test/path',
+            json={'data': 'test'}
+        )
+
+        # Test PUT request
+        client._put_request('/test/path', {'data': 'test'})
+        mock_session.put.assert_called_with(
+            self.custom_base_url + '/test/path',
+            json={'data': 'test'}
+        )
+
+        # Test DELETE request
+        client._delete_request('/test/path')
+        mock_session.delete.assert_called_with(
+            self.custom_base_url + '/test/path'
+        )
+
+    def test_utils_extract_order_id_with_custom_domain(self):
+        """Test that Utils.extract_order_id works with custom domains"""
+        # Create a mock client
+        mock_client = MagicMock()
+
+        # Create Utils instance
+        utils = Utils(mock_client, 'test_account_hash')
+
+        # Test with various custom domains
+        test_cases = [
+            'https://api.schwabapi.com/trader/v1/accounts/test_account_hash/orders/12345',
+            'https://proxy.example.com/trader/v1/accounts/test_account_hash/orders/12345',
+            'https://localhost:8080/trader/v1/accounts/test_account_hash/orders/12345',
+        ]
+
+        for location_url in test_cases:
+            # Create mock response
+            mock_response = MagicMock()
+            mock_response.is_error = False
+            mock_response.headers = {'Location': location_url}
+
+            # Extract order ID
+            order_id = utils.extract_order_id(mock_response)
+
+            # Verify it extracted the correct order ID
+            self.assertEqual(order_id, 12345)
+
+    def test_default_base_url_unchanged(self):
+        """Test that DEFAULT_BASE_URL is still the original value"""
+        self.assertEqual(DEFAULT_BASE_URL, 'https://api.schwabapi.com')
+
+    @patch('schwab.auth.Client')
+    @patch('schwab.auth.OAuth2Client')
+    def test_backwards_compatibility_no_base_url(self, mock_oauth, mock_client):
+        """Test that not specifying base_url uses the default"""
+        self.write_token()
+
+        # Call without base_url parameter
+        auth.client_from_token_file(
+            self.token_path, self.api_key, self.app_secret
+        )
+
+        # Verify Client was called with default base_url
+        mock_client.assert_called_once_with(
+            self.api_key, _, token_metadata=_, enforce_enums=True,
+            base_url=DEFAULT_BASE_URL
+        )
+
+        # Verify OAuth2Client was called with default token endpoint
+        mock_oauth.assert_called_once()
+        call_args = mock_oauth.call_args[1]
+        self.assertEqual(
+            call_args['token_endpoint'],
+            DEFAULT_BASE_URL + '/v1/oauth/token'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_base_url_async.py
+++ b/tests/test_base_url_async.py
@@ -1,0 +1,71 @@
+"""Async tests for custom base_url functionality"""
+
+import unittest
+from schwab.client.asynchronous import AsyncClient
+from unittest.mock import MagicMock
+
+
+class AsyncCustomBaseUrlTest(unittest.IsolatedAsyncioTestCase):
+    """Test that async client HTTP methods use custom base URLs"""
+
+    async def test_async_client_http_methods_use_base_url(self):
+        """Test that async client HTTP methods use the base_url"""
+        custom_base_url = 'https://proxy.example.com'
+        api_key = 'TEST_API_KEY'
+
+        # Create a mock async session
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+
+        # Mock async methods
+        async def mock_get(*args, **kwargs):
+            return mock_response
+        async def mock_post(*args, **kwargs):
+            return mock_response
+        async def mock_put(*args, **kwargs):
+            return mock_response
+        async def mock_delete(*args, **kwargs):
+            return mock_response
+
+        mock_session.get = MagicMock(side_effect=mock_get)
+        mock_session.post = MagicMock(side_effect=mock_post)
+        mock_session.put = MagicMock(side_effect=mock_put)
+        mock_session.delete = MagicMock(side_effect=mock_delete)
+
+        # Create async client with custom base URL
+        client = AsyncClient(
+            api_key=api_key,
+            session=mock_session,
+            base_url=custom_base_url
+        )
+
+        # Test GET request
+        await client._get_request('/test/path', {})
+        mock_session.get.assert_called_with(
+            custom_base_url + '/test/path',
+            params={}
+        )
+
+        # Test POST request
+        await client._post_request('/test/path', {'data': 'test'})
+        mock_session.post.assert_called_with(
+            custom_base_url + '/test/path',
+            json={'data': 'test'}
+        )
+
+        # Test PUT request
+        await client._put_request('/test/path', {'data': 'test'})
+        mock_session.put.assert_called_with(
+            custom_base_url + '/test/path',
+            json={'data': 'test'}
+        )
+
+        # Test DELETE request
+        await client._delete_request('/test/path')
+        mock_session.delete.assert_called_with(
+            custom_base_url + '/test/path'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Allow users to specify a custom base URL for all API endpoints via an optional `base_url` parameter in client creations functions. Defaults to the official endpoint when not specified.

This enables the use of proxy server to multiplex multiple applications through a single API app registration, working around the limitation of one application per personal account.